### PR TITLE
Enesured that fromEagerPromise is always promise-based

### DIFF
--- a/src/fromEagerPromise.js
+++ b/src/fromEagerPromise.js
@@ -2,12 +2,12 @@ import { create } from '@most/create';
 
 const fromEagerPromise = (f) => {
   return create((add, end, error) => {
-    const rawPromise = f();
-
-    return rawPromise.then((data) => {
-      add(data);
-      end();
-    }, error);
+    return Promise.resolve()
+      .then(f)
+      .then((data) => {
+        add(data);
+        end();
+      }, error);
   });
 };
 


### PR DESCRIPTION
Basically toArray was calling fromEagerPromise with a function that returned a non-promise-type. It makes sense to have fromEagerPromise always return a promise so if you call it with a function that is not promisey, it will effectively just delay the callback to that function.

`Promise.resolve().then(f)` means it will evaluate f and if it returns a promise, it will consume it, otherwise it will just pass the resulting value on to the next step of the chain.